### PR TITLE
fix compiling error

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -164,6 +164,7 @@ static int nixio_pipe(lua_State *L) {
 	*udata = pipefd[1];
 	lua_pushvalue(L, -3);
 	lua_setmetatable(L, -2);
+	lua_remove(L, -3);
 
 	return 2;
 }

--- a/src/process.c
+++ b/src/process.c
@@ -73,7 +73,7 @@ int nixio__exec(lua_State *L, int m) {
 					return luaL_error(L, "stack overflow");
 				}
 
-				if (!lua_type(L, -2) != LUA_TSTRING || !lua_isstring(L, -1)) {
+				if (!lua_isstring(L, -2) || !lua_isstring(L, -1)) {
 					return luaL_argerror(L, 3, "invalid environment");
 				}
 


### PR DESCRIPTION
To make parameters conditions consistent and fix the compiling error below :
gcc  -O2 --std=gnu99 -Wall -Werror -pedantic  -O2 -fPIC -I/usr/local/include -fPIC -c -o src/process.o src/process.c
src/process.c: In function 'nixio__exec':
src/process.c:76:26: error: comparison of constant '4' with boolean expression is always true [-Werror=bool-compare]
     if (!lua_type(L, -2) != LUA_TSTRING || !lua_isstring(L, -1)) {
                          ^
src/process.c:76:26: error: logical not is only applied to the left hand side of comparison [-Werror=logical-not-parentheses]
cc1: all warnings being treated as errors
make: *** [src/process.o] Error 1
Makefile:68: recipe for target 'src/process.o' failed

Error: Build error: Failed building.