### PR TITLE
Define nixio__bin2hex as extern to avoid multiple defs

### DIFF
--- a/src/nixio.h
+++ b/src/nixio.h
@@ -103,7 +103,7 @@ int nixio__mode_write(int mode, char *modestr);
 
 int nixio__push_stat(lua_State *L, nixio_stat_t *buf);
 
-const char nixio__bin2hex[16];
+extern const char nixio__bin2hex[16];
 
 /* Module functions */
 void nixio_open_file(lua_State *L);


### PR DESCRIPTION
How anyone could get the code to compile in the past 9-10 years without receiving `nixio__bin2hex` being defined in every C file. This patch defines `nixio__bin2hex` as an external in `nixio.h` so that each object file can reference `nixio__bin2hex` but only `binary.c` will actually define it.  